### PR TITLE
fix: generate correct content-disposition for utf-8 file names

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const pump = util.promisify(pipeline);
 
 const fastifyMultipart = require('fastify-multipart');
 const graaspFileUploadLimiter = require('graasp-file-upload-limiter');
+const contentDisposition = require('content-disposition');
 
 // const createError = require('fastify-error');
 // const SomeError = createError('FST_GFIERR001', 'Unable to \'%s\' of %s');
@@ -154,7 +155,7 @@ module.exports = async (fastify, options) => {
     reply.type(mimetype);
     // this header will make the browser download the file with 'name' instead of
     // simply opening it and showing it
-    reply.header('Content-Disposition', `attachment; filename="${name}"`);
+    reply.header('Content-Disposition', contentDisposition(name));
 
     // TODO: can/should this be done in a worker (fastify piscina)?
     return fs.createReadStream(`${storageRootPath}/${path}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,6 +148,21 @@
         "typedarray": "^0.0.6"
       }
     },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        }
+      }
+    },
     "cookie": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "fastify-error: ~0.2.0"
   ],
   "dependencies": {
+    "content-disposition": "^0.5.3",
     "fastify-multipart": "^4.0.0",
     "graasp-file-upload-limiter": "git://github.com/graasp/graasp-file-upload-limiter#main"
   },


### PR DESCRIPTION
It uses the content-disposition package to generate valid content-disposition, the package handles utf-8 files names

closes #5